### PR TITLE
Tests and fixtures for valueSetMapper

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
     "endOfLine":"auto",
     "printWidth":120,
     "tabWidth":2,
-    "singleQuote":true
+    "singleQuote":true,
+    "trailingComma": "all"
 }

--- a/assurance/fixtures/valuesets/example-valueset-1.json
+++ b/assurance/fixtures/valuesets/example-valueset-1.json
@@ -1,0 +1,25 @@
+{
+  "resourceType": "ValueSet",
+  "id": "example-valueset-1",
+  "url": "http://example.com/example-valueset-1",
+  "status": "draft",
+  "version": "1",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.com",
+        "version": "1",
+        "concept": [
+          {
+            "code": "example-code-1",
+            "display": "Example Code 1"
+          },
+          {
+            "code": "example-code-2",
+            "display": "Example Code 2"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/assurance/fixtures/valuesets/example-valueset-2.json
+++ b/assurance/fixtures/valuesets/example-valueset-2.json
@@ -1,0 +1,21 @@
+{
+  "resourceType": "ValueSet",
+  "id": "example-valueset-2",
+  "url": "http://example.com/example-valueset-2",
+  "status": "draft",
+  "version": "1",
+  "compose": {
+    "include": [
+      {
+        "system": "http://example.com",
+        "version": "1",
+        "concept": [
+          {
+            "code": "example-code-3",
+            "display": "Example Code 3"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/assurance/valueSetMapper.test.js
+++ b/assurance/valueSetMapper.test.js
@@ -1,0 +1,46 @@
+const { mapValueSets } = require('../test/helpers/valueSetMapper');
+const exampleValueSet1 = require('./fixtures/valuesets/example-valueset-1.json');
+const exampleValueSet2 = require('./fixtures/valuesets/example-valueset-2.json');
+
+describe('valueSetMapper', () => {
+  test('valueSetMapper should include all codes', () => {
+    const map = mapValueSets([exampleValueSet1, exampleValueSet2]);
+
+    // map should key both URLs
+    const vsetUrls = Object.keys(map);
+    expect(vsetUrls).toHaveLength(2);
+    expect(vsetUrls).toEqual(expect.arrayContaining([exampleValueSet1.url, exampleValueSet2.url]));
+
+    const vs1Entry = map[exampleValueSet1.url];
+    const vs1Codes = vs1Entry[exampleValueSet1.version];
+    const vs2Entry = map[exampleValueSet2.url];
+    const vs2Codes = vs2Entry[exampleValueSet2.version];
+
+    // This entry of the map should contain all codes defined in compose.include
+    expect(vs1Codes).toBeDefined();
+    expect(vs2Codes).toBeDefined();
+
+    // Check all codes listed
+    exampleValueSet1.compose.include.forEach((i) => {
+      expect(vs1Codes).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            system: i.system,
+            version: i.version,
+          }),
+        ]),
+      );
+
+      i.concept.forEach((c) => {
+        expect(vs1Codes).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              code: c.code,
+              display: c.display,
+            }),
+          ]),
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
2 fixtures and a test that ensures that the valueSetMapper takes all codes across the valueSet fixtures and includes them in the lookup map.

`yarn test:assurance`
