### PR TITLE
Update build script to detect when translation is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn test
 This script will do the following:
 
 1. Start a [cql-translation-service](https://github.com/cqframework/cql-translation-service) docker container
-2. Translate all CQL in the `./src` directory into ELM JSON and write it to `./build`
+2. Translate all CQL in the `./src` directory into ELM JSON and write it to `./build`. This will only occur if CQL files in the `src` have changed and the ELM needs to be updated
 3. Run the unit tests present in `./test`
 
 To only do steps 2. and 3. above without starting a new container:


### PR DESCRIPTION
Build script will now use the modified Time of the file descriptor for both the ELM and CQL to determine when translation is needed (i.e. when CQL is modified more recently than existing ELM, _if_ existing ELM is present in the build directory).

To test, I recommend just starting a docker container and using the `yarn translate` command for various cases described below:

```
docker run -p 8080:8080 -d cqframework/cql-translation-service:latest
```

1. After a fresh pull, `yarn translate` should skip translation since there are no changes
2. Modify mcode.cql. `yarn translate` should translate and write the elm
3. Do nothing, just run `yarn translate` again, and it should skip translation
4. Create a brand new cql file, `yarn translate` should pick it up and write the elm
5. Do nothing, just run `yarn translate` again, and it should skip translation for both mcode and the new CQL file

There could be some cases other than the process outlined there, but you get this gist.