### PR TITLE
Adding entrypoint to check OS and run correct script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "eslint \"./**/*.js\" --fix",
     "prettier": "prettier --check \"**/*.js\"",
     "prettier:fix": "prettier --write \"**/*.js\"",
-    "test": "./testing-harness/scripts/run_tests.sh",
+    "test": "node ./testing-harness/run.js",
     "test:unit": "jest --testPathPattern=test --testPathIgnorePatterns=testing-harness",
     "translate": "node ./testing-harness/scripts/buildElm.js",
     "test:testing-harness": "jest --testPathPattern=./testing-harness/test",

--- a/testing-harness/run.js
+++ b/testing-harness/run.js
@@ -4,7 +4,7 @@ const { spawn } = require('child_process');
 
 const args = process.argv.slice(2);
 if (process.platform === 'win32') {
-  spawn('./testing-harness/scripts/run_tests.ps1', args, { shell: 'powershell.exe', stdio: 'inherit' });
+  spawn('testing-harness\\scripts\\run_tests.bat', args, { stdio: 'inherit' });
 } else {
   spawn('./testing-harness/scripts/run_tests.sh', args, { stdio: 'inherit' });
 }

--- a/testing-harness/run.js
+++ b/testing-harness/run.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+const { spawn } = require('child_process');
+
+const args = process.argv.slice(2);
+if (process.platform === 'win32') {
+  spawn('./testing-harness/scripts/run_tests.ps1', args, { shell: 'powershell.exe', stdio: 'inherit' });
+} else {
+  spawn('./testing-harness/scripts/run_tests.sh', args, { stdio: 'inherit' });
+}


### PR DESCRIPTION
There is now a `run.js` file in the testing harness that will be called by `yarn test` instead of directly calling the testing script. `run.js` will check what operating system the program is being run on and call the appropriate script and pass along any command line arguments.

To test this, run `yarn test` on both Windows and non-Windows operating systems and make sure the correct script is being run. Since the PR for the windows script has not been merged yet, you will need to either copy the `run_tests.ps1` file from that PR or create a temporary script named `run_tests.ps1` in the scripts folder (you can just have it do something like `Write-Output "test"` to see that it works).