### PR TITLE
Support multiple CQL input paths

### DIFF
--- a/testing-harness/scripts/buildElm.js
+++ b/testing-harness/scripts/buildElm.js
@@ -3,7 +3,7 @@ const path = require('path');
 const dotenv = require('dotenv');
 const { Client } = require('cql-translation-service-client');
 
-const cqlPathString = process.argv[2] ? path.resolve(process.argv[2]) : path.join(__dirname, '../../cql');
+const cqlPathString = process.argv[2] ? process.argv[2] : path.join(__dirname, '../../cql');
 const buildPath = process.argv[3] ? path.resolve(process.argv[3]) : path.join(__dirname, '../../output-elm');
 
 dotenv.config();
@@ -20,6 +20,7 @@ const client = new Client(TRANSLATION_SERVICE_URL);
 async function translateCQL() {
   const cqlPaths = cqlPathString.split(',');
   const cqlFiles = cqlPaths
+    .map((p) => path.resolve(p))
     .map((cqlPath) => {
       const fileNames = fs.readdirSync(cqlPath).filter((f) => path.extname(f) === '.cql');
       return fileNames.map((f) => path.join(cqlPath, f));

--- a/testing-harness/scripts/buildElm.js
+++ b/testing-harness/scripts/buildElm.js
@@ -19,10 +19,12 @@ const client = new Client(TRANSLATION_SERVICE_URL);
  */
 async function translateCQL() {
   const cqlPaths = cqlPathString.split(',');
-  const cqlFiles = cqlPaths.map((cqlPath) => {
-    const fileNames = fs.readdirSync(cqlPath).filter((f) => path.extname(f) === '.cql');
-    return fileNames.map((f) => path.join(cqlPath, f));
-  }).flat();
+  const cqlFiles = cqlPaths
+    .map((cqlPath) => {
+      const fileNames = fs.readdirSync(cqlPath).filter((f) => path.extname(f) === '.cql');
+      return fileNames.map((f) => path.join(cqlPath, f));
+    })
+    .flat();
   const cqlRequestBody = {};
   let includeCQL = false;
 


### PR DESCRIPTION
This PR supports including multiple CQL input paths. For now, multiple paths can be included in the command line arguments, but eventually, this will be provided through the environment variable. You can include multiple paths by listing each input directly in a comma separated string value, such as `cql,test/fixtures/cql`.

This PR also makes it so that if any CQL file has changed more recently than its corresponding ELM file, all CQL files are included when converting CQL. This ensures that any libraries with dependencies are properly converted to ELM.