### PR TITLE
Paths to files are mediated by ENV variables now

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,5 @@
 TRANSLATION_SERVICE_URL=http://secondUrl.com
+INPUT_CQL='./cql'
+OUTPUT_ELM='./output-elm'
+VALUESETS='./valuesets'
+PATIENTS='./test/fixtures'

--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@ TRANSLATION_SERVICE_URL=http://secondUrl.com
 INPUT_CQL='./cql'
 OUTPUT_ELM='./output-elm'
 VALUESETS='./valuesets'
-PATIENTS='./test/fixtures'
+PATIENTS='./test/fixtures/patients'

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 TRANSLATION_SERVICE_URL=http://secondUrl.com
-INPUT_CQL='./cql'
-OUTPUT_ELM='./output-elm'
-VALUESETS='./valuesets'
-PATIENTS='./test/fixtures/patients'
+INPUT_CQL=./cql
+OUTPUT_ELM=./output-elm
+VALUESETS=./valuesets
+PATIENTS=./test/fixtures/patients

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 TRANSLATION_SERVICE_URL=http://localhost:8080/cql/translator
-INPUT_CQL='./testing-harness/test/fixtures/cql'
-OUTPUT_ELM='./testing-harness/test/fixtures/elm'
-VALUESETS='./testing-harness/test/fixtures/valuesets'
-PATIENTS='./testing-harness/test/fixtures/patients'
+INPUT_CQL=./testing-harness/test/fixtures/cql
+OUTPUT_ELM=./testing-harness/test/fixtures/elm
+VALUESETS=./testing-harness/test/fixtures/valuesets
+PATIENTS=./testing-harness/test/fixtures/patients

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+TRANSLATION_SERVICE_URL=http://localhost:8080/cql/translator
+INPUT_CQL='./testing-harness/test/fixtures/cql'
+OUTPUT_ELM='./testing-harness/test/fixtures/elm'
+VALUESETS='./testing-harness/test/fixtures/valuesets'
+PATIENTS='./testing-harness/test/fixtures/patients'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,11 +34,11 @@ jobs:
     name: Run tests
     runs-on: ubuntu-latest
     env:
-      TRANSLATION_SERVICE_URL=http://localhost:8080/cql/translator
-      INPUT_CQL=./cql
-      OUTPUT_ELM=./output-elm
-      VALUESETS=./valuesets
-      PATIENTS=./test/fixtures/patients
+      TRANSLATION_SERVICE_URL: http://localhost:8080/cql/translator
+      INPUT_CQL: ./cql
+      OUTPUT_ELM: ./output-elm
+      VALUESETS: ./valuesets
+      PATIENTS: ./test/fixtures/patients
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,11 +33,12 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
-    env: TRANSLATION_SERVICE_URL=http://localhost:8080/cql/translator
-      INPUT_CQL='./cql'
-      OUTPUT_ELM='./output-elm'
-      VALUESETS='./valuesets'
-      PATIENTS='./test/fixtures/patients'
+    env:
+      TRANSLATION_SERVICE_URL=http://localhost:8080/cql/translator
+      INPUT_CQL=./cql
+      OUTPUT_ELM=./output-elm
+      VALUESETS=./valuesets
+      PATIENTS=./test/fixtures/patients
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    env: TRANSLATION_SERVICE_URL=http://localhost:8080/cql/translator
+      INPUT_CQL='./cql'
+      OUTPUT_ELM='./output-elm'
+      VALUESETS='./valuesets'
+      PATIENTS='./test/fixtures/patients'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,10 @@ jobs:
       - run: chmod +x ./testing-harness/scripts/run_tests.sh
       - run: yarn test
       # Defining a new ENV variable set for our testing-harness tests
-      - env:
-        INPUT_CQL: ./testing-harness/test/fixtures/cql
-        OUTPUT_ELM: ./testing-harness/test/fixtures/elm
-        VALUESETS: ./testing-harness/test/fixtures/valuesets
-        PATIENTS: ./testing-harness/test/fixtures/patients
-      - run: yarn test:testing-harness
+      - name: 'testing-harness tests'
+        env:
+          INPUT_CQL: ./testing-harness/test/fixtures/cql
+          OUTPUT_ELM: ./testing-harness/test/fixtures/elm
+          VALUESETS: ./testing-harness/test/fixtures/valuesets
+          PATIENTS: ./testing-harness/test/fixtures/patients
+        run: yarn test:testing-harness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TRANSLATION_SERVICE_URL: http://localhost:8080/cql/translator
-      INPUT_CQL: ./cql
-      OUTPUT_ELM: ./output-elm
-      VALUESETS: ./valuesets
-      PATIENTS: ./test/fixtures/patients
+      INPUT_CQL: './cql'
+      OUTPUT_ELM: './output-elm'
+      VALUESETS: './valuesets'
+      PATIENTS: './test/fixtures/patients'
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TRANSLATION_SERVICE_URL: http://localhost:8080/cql/translator
-      INPUT_CQL: './cql'
-      OUTPUT_ELM: './output-elm'
-      VALUESETS: './valuesets'
-      PATIENTS: './test/fixtures/patients'
+      INPUT_CQL: ./cql
+      OUTPUT_ELM: ./output-elm
+      VALUESETS: ./valuesets
+      PATIENTS: ./test/fixtures/patients
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
@@ -49,4 +49,10 @@ jobs:
           cmd: install --frozen-lockfile
       - run: chmod +x ./testing-harness/scripts/run_tests.sh
       - run: yarn test
+      # Defining a new ENV variable set for our testing-harness tests
+      - env:
+        INPUT_CQL: ./testing-harness/test/fixtures/cql
+        OUTPUT_ELM: ./testing-harness/test/fixtures/elm
+        VALUESETS: ./testing-harness/test/fixtures/valuesets
+        PATIENTS: ./testing-harness/test/fixtures/patients
       - run: yarn test:testing-harness

--- a/README.md
+++ b/README.md
@@ -4,12 +4,23 @@
 
 ![testing architecture](https://user-images.githubusercontent.com/16297930/109518787-963a4f00-7a78-11eb-8a0f-5be82a011bb7.png)
 
-
 ### Prerequisites
 
 * [Docker](https://docker.com)
 * [Node.js](https://nodejs.org/en/)
 * [Yarn](https://classic.yarnpkg.com/en/)
+
+Users also need to configure a `.env` file, defining the following values:
+
+```bash
+TRANSLATION_SERVICE_URL=http://example.com  # An endpoint exposing a CQL translation service
+INPUT_CQL='./cql'                           # Folder containing all CQL to translate
+VALUESETS='./valuesets'                     # Folder where CQL-dependent valuesets live
+OUTPUT_ELM='./output-elm'                   # Folder where translated ELM will be saved
+PATIENTS='./test/fixtures/patients'         # Folder storing patient files used as test fixtures
+```
+
+Provisional values are provided in the `.env.example` file. To start with these values, simply copy these contents into a new file called `.env`.
 
 ### Test Script
 
@@ -22,7 +33,7 @@ yarn test
 This script will do the following:
 
 1. Start a [cql-translation-service](https://github.com/cqframework/cql-translation-service) docker container
-2. Translate all CQL in the `./src` directory into ELM JSON and write it to `./build`. This will only occur if CQL files in the `src` have changed and the ELM needs to be updated
+2. Translate all CQL in the`INPUT_CQL` directory into ELM JSON and write it to `OUTPUT_ELM`. This will only occur if CQL files in the `INPUT_CQL` have changed and the ELM needs to be updated
 3. Run the unit tests present in `./test`
 
 To only do steps 2. and 3. above without starting a new container:
@@ -35,7 +46,7 @@ yarn test -n
 
 The unit tests will make assertions based on the execution results of the mCODE CQL for a given patient. Before any unit tests are run, the CQL is executed using [cql-execution](https://github.com/cqframework/cql-execution/) and [cql-exec-fhir](https://github.com/cqframework/cql-exec-fhir), and the execution results are stored in a variable to be used for assertions in the unit tests.
 
-To run only the unit tests with the existing ELM in `./build` (and not re-translate the CQL):
+To run only the unit tests with the existing ELM in `OUTPUT_ELM` (and not re-translate the CQL):
 
 ``` bash
 yarn test:unit
@@ -51,15 +62,16 @@ yarn translate
 ```
 
 To stop the docker container once translation is complete, run the following command:
+
 ``` bash
 docker stop cql-translation-service
 ```
 
-The default URL used for the translation service is `http://localhost:8080/cql/translator`, however that can be configured by setting the `TRANSLATION_SERVICE_URL` node environment variable. This variable can be set at runtime like so:
+The default URL used for the translation service is `http://localhost:8080/cql/translator`, however that can be configured by setting the `TRANSLATION_SERVICE_URL` node environment variable. This variable can be set by modifying the `TRANSLATION_SERVICE_URL` value in your `.env` file, or by providing a new value at runtime like so:
+
 ``` bash
 TRANSLATION_SERVICE_URL=http://preferredURL.com yarn translate
 ```
-Additionally, the variable can be set in perpetuity by creating a `.env` file within the base diretory of `mcode-cql` and setting the variable there. This can be done by renaming the `.env.example` file in the base `mcode-cql` directory to `.env`, then changing the example url in the file to a URL of your choosing.
 
 When translating CQL with a custom URL, `yarn test` should be run with the `-n` flag to prevent the testing harness from starting a new docker container.
 
@@ -68,12 +80,14 @@ When translating CQL with a custom URL, `yarn test` should be run with the `-n` 
 The `testing-harness/test` folder contains tests and fixtures for validating the functionality of the testing harness infrastructure.
 
 Example CQL for testing translation in the `testing-harness/test/fixtures/cql` subdirectory. To build this CQL into ELM, spin up a cql-translation-service docker container and run the `yarn translate:testing-harness` script:
+
 ``` bash
 docker run -d -p 8080:8080 cqframework/cql-translation-service
 yarn translate:testing-harness
 ```
 
 To only run the utility function unit tests while excluding mCODE assertion tests, run the `test:testing-harness` script:
+
 ``` bash
 yarn test:testing-harness
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:unit": "jest --testPathPattern=test --testPathIgnorePatterns=testing-harness",
     "translate": "node ./testing-harness/scripts/buildElm.js",
     "test:testing-harness": "jest --testPathPattern=./testing-harness/test",
-    "translate:testing-harness": "node testing-harness/scripts/buildElm.js testing-harness/test/fixtures/cql testing-harness/test/fixtures/elm"
+    "translate:testing-harness": "node testing-harness/scripts/buildElm.js .env.test"
   },
   "devDependencies": {
     "eslint": "^7.20.0",

--- a/test/mCODE.test.js
+++ b/test/mCODE.test.js
@@ -1,15 +1,18 @@
-const path = require('path');
-const { loadJSONFromDirectory } = require('../testing-harness/fixtureLoader');
+const dotenv = require('dotenv');
+const { defaultLoadElm, defaultLoadPatients, defaultLoadValuesets } = require('../testing-harness/fixtureLoader');
 const { mapValueSets } = require('../testing-harness/valueSetMapper');
 const { execute } = require('../testing-harness/execution');
+
+// Initialize the env variables
+dotenv.config();
 
 let executionResults;
 beforeAll(() => {
   // Set up necessary data for cql-execution
-  const valueSets = loadJSONFromDirectory(path.resolve(__dirname, '../valuesets'));
+  const valueSets = defaultLoadValuesets();
   const valueSetMap = mapValueSets(valueSets);
-  const elm = loadJSONFromDirectory(path.resolve(__dirname, '../output-elm'));
-  const patientBundles = loadJSONFromDirectory(path.resolve(__dirname, './fixtures/patients'));
+  const elm = defaultLoadElm();
+  const patientBundles = defaultLoadPatients();
 
   executionResults = execute(elm, patientBundles, valueSetMap);
   console.log(executionResults);

--- a/testing-harness/execution.js
+++ b/testing-harness/execution.js
@@ -12,7 +12,9 @@ const { PatientSource } = require('cql-exec-fhir');
 function execute(elmJSONs, patientBundles, valueSetMap, libraryID = 'mCODE') {
   // 'main' ELM is the mcode library
   const mainELM = elmJSONs.find((e) => e.library.identifier.id === libraryID);
-
+  if (!mainELM) {
+    throw Error(`Cannot find ELM library with library id ${libraryID}`);
+  }
   // Resolve dependencies
   const repository = new cql.Repository(elmJSONs);
   const library = repository.resolve(libraryID, mainELM.library.identifier.version);

--- a/testing-harness/fixtureLoader.js
+++ b/testing-harness/fixtureLoader.js
@@ -29,6 +29,10 @@ function loadJSONFixture(pathToFixture) {
  * @returns {Array} array of JSON parsed Elm
  */
 function defaultLoadElm() {
+  // Ensure that env variables are defined
+  if (!process.env.OUTPUT_ELM) {
+    throw Error('Unable to find env value for OUTPUT_ELM; make sure you set this in your .env file');
+  }
   const elmPath = path.resolve(process.cwd(), process.env.OUTPUT_ELM);
   return loadJSONFromDirectory(elmPath);
 }
@@ -39,6 +43,10 @@ function defaultLoadElm() {
  * @returns {Array} array of JSON parsed Patients
  */
 function defaultLoadPatients() {
+  // Ensure that env variables are defined
+  if (!process.env.PATIENTS) {
+    throw Error('Unable to find env value for PATIENTS; make sure you set this in your .env file');
+  }
   const patientsPath = path.resolve(process.cwd(), process.env.PATIENTS);
   return loadJSONFromDirectory(patientsPath);
 }
@@ -49,6 +57,10 @@ function defaultLoadPatients() {
  * @returns {Array} array of JSON parsed Valuesets
  */
 function defaultLoadValuesets() {
+  // Ensure that env variables are defined
+  if (!process.env.VALUESETS) {
+    throw Error('Unable to find env value for VALUESETS; make sure you set this in your .env file');
+  }
   const valuesetsPath = path.resolve(process.cwd(), process.env.VALUESETS);
   return loadJSONFromDirectory(valuesetsPath);
 }

--- a/testing-harness/fixtureLoader.js
+++ b/testing-harness/fixtureLoader.js
@@ -23,7 +23,40 @@ function loadJSONFixture(pathToFixture) {
   return JSON.parse(f);
 }
 
+/**
+ * Default loader for Elm
+ *
+ * @returns {Array} array of JSON parsed Elm
+ */
+function defaultLoadElm() {
+  const elmPath = path.resolve(process.cwd(), process.env.OUTPUT_ELM);
+  return loadJSONFromDirectory(elmPath);
+}
+
+/**
+ * Default loader for Patients
+ *
+ * @returns {Array} array of JSON parsed Patients
+ */
+function defaultLoadPatients() {
+  const patientsPath = path.resolve(process.cwd(), process.env.PATIENTS);
+  return loadJSONFromDirectory(patientsPath);
+}
+
+/**
+ * Default loader for Valuesets
+ *
+ * @returns {Array} array of JSON parsed Valuesets
+ */
+function defaultLoadValuesets() {
+  const valuesetsPath = path.resolve(process.cwd(), process.env.VALUESETS);
+  return loadJSONFromDirectory(valuesetsPath);
+}
+
 module.exports = {
   loadJSONFixture,
   loadJSONFromDirectory,
+  defaultLoadElm,
+  defaultLoadPatients,
+  defaultLoadValuesets,
 };

--- a/testing-harness/scripts/buildElm.js
+++ b/testing-harness/scripts/buildElm.js
@@ -3,10 +3,13 @@ const path = require('path');
 const dotenv = require('dotenv');
 const { Client } = require('cql-translation-service-client');
 
-const cqlPathString = process.argv[2] ? process.argv[2] : path.join(__dirname, '../../cql');
-const buildPath = process.argv[3] ? path.resolve(process.argv[3]) : path.join(__dirname, '../../output-elm');
+// Initialize process.env with either `.env` or a custom file
+const envPath = process.argv[2] ? path.resolve(process.cwd(), process.argv[2]) : path.resolve(process.cwd(), '.env');
+dotenv.config({ path: envPath });
 
-dotenv.config();
+const cqlPathString = path.resolve(process.cwd(), process.env.INPUT_CQL);
+const buildPathString = path.resolve(process.cwd(), process.env.OUTPUT_ELM);
+
 const TRANSLATION_SERVICE_URL = !process.env.TRANSLATION_SERVICE_URL
   ? 'http://localhost:8080/cql/translator'
   : process.env.TRANSLATION_SERVICE_URL;
@@ -32,13 +35,13 @@ async function translateCQL() {
   cqlFiles.forEach((cqlFilePath) => {
     // Check if ELM already exists to see if translation is needed
     const correspondingElm = fs
-      .readdirSync(buildPath)
+      .readdirSync(buildPathString)
       .find((elmFile) => path.basename(elmFile, '.json') === path.basename(cqlFilePath, '.cql'));
 
     // If ELM exists in build, compare timestamps
     if (correspondingElm) {
       const cqlStat = fs.statSync(cqlFilePath);
-      const elmStat = fs.statSync(path.join(buildPath, correspondingElm));
+      const elmStat = fs.statSync(path.join(buildPathString, correspondingElm));
 
       // cql file was modified more recently
       if (cqlStat.mtimeMs > elmStat.mtimeMs) {
@@ -91,7 +94,7 @@ translateCQL()
     Object.entries(libraries).forEach(([libName, elm]) => {
       const errors = processErrors(elm);
       if (errors.length === 0) {
-        const elmPath = path.join(buildPath, `${libName}.json`);
+        const elmPath = path.join(buildPathString, `${libName}.json`);
         fs.writeFileSync(elmPath, JSON.stringify(elm), 'utf8');
         console.log(`Wrote ELM to ${elmPath}`);
       } else {

--- a/testing-harness/scripts/buildElm.js
+++ b/testing-harness/scripts/buildElm.js
@@ -7,6 +7,11 @@ const { Client } = require('cql-translation-service-client');
 const envPath = process.argv[2] ? path.resolve(process.cwd(), process.argv[2]) : path.resolve(process.cwd(), '.env');
 dotenv.config({ path: envPath });
 
+// Ensure that env variables are defined
+if (!(process.env.INPUT_CQL && process.env.OUTPUT_ELM)) {
+  throw Error(`Unable to find ENV values for INPUT_CQL or OUTPUT_ELM in ${envPath}`);
+}
+
 const cqlPathString = path.resolve(process.cwd(), process.env.INPUT_CQL);
 const buildPathString = path.resolve(process.cwd(), process.env.OUTPUT_ELM);
 

--- a/testing-harness/test/execution.test.js
+++ b/testing-harness/test/execution.test.js
@@ -1,11 +1,22 @@
+const dotenv = require('dotenv');
 const path = require('path');
 const { execute } = require('../execution');
 const { mapValueSets } = require('../valueSetMapper');
-const { loadJSONFixture, loadJSONFromDirectory } = require('../fixtureLoader');
+const {
+  loadJSONFixture,
+  loadJSONFromDirectory,
+  defaultLoadElm,
+  defaultLoadPatients,
+  defaultLoadValuesets,
+} = require('../fixtureLoader');
+
+// Initialize the env variables
+dotenv.config({ path: path.resolve(process.cwd(), '.env.test') });
 
 let valueSetMap;
 let elm;
-let patientBundle;
+let patientBundles;
+let firstPatientBundle;
 
 beforeAll(() => {
   // Set up necessary data for cql-execution
@@ -19,13 +30,14 @@ beforeAll(() => {
       ],
     },
   };
-  elm = loadJSONFixture(path.resolve(__dirname, 'fixtures/elm/testLib.json'));
-  patientBundle = loadJSONFixture(path.resolve(__dirname, './fixtures/patients/test-patient-1.json'));
-});
 
+  elm = defaultLoadElm();
+  patientBundles = defaultLoadPatients();
+  [firstPatientBundle] = patientBundles;
+});
 test('Should properly match on resources in execution', () => {
-  const expectedCondition = patientBundle.entry[0].resource;
-  const executionResults = execute([elm], patientBundle, valueSetMap, 'testLib');
+  const expectedCondition = firstPatientBundle.entry[0].resource;
+  const executionResults = execute(elm, firstPatientBundle, valueSetMap, 'testLib');
   const patientID = '123';
 
   expect(executionResults.patientResults[patientID].Condition).toHaveLength(1);
@@ -44,7 +56,7 @@ test('Should exclude resources with values outside of the valueSet Map during ex
       ],
     },
   };
-  const executionResults = execute([elm], patientBundle, alteredVSMap, 'testLib');
+  const executionResults = execute(elm, firstPatientBundle, alteredVSMap, 'testLib');
   const patientID = '123';
 
   // There should be no matching Condition resources within the execution results
@@ -52,16 +64,16 @@ test('Should exclude resources with values outside of the valueSet Map during ex
 });
 
 test('Should properly load patient resource from bundle', () => {
-  const executionResults = execute([elm], patientBundle, valueSetMap, 'testLib');
+  const executionResults = execute(elm, firstPatientBundle, valueSetMap, 'testLib');
   const patientID = '123';
 
   const returnedPatient = executionResults.patientResults[patientID].Patient._json;
-  expect(returnedPatient).toEqual(patientBundle.entry[1].resource);
+  expect(returnedPatient).toEqual(firstPatientBundle.entry[1].resource);
 });
 
 test('Should properly load multiple patient resources from array', () => {
   const patientBundles = loadJSONFromDirectory(path.resolve(__dirname, './fixtures/patients'));
-  const executionResults = execute([elm], patientBundles, valueSetMap, 'testLib');
+  const executionResults = execute(elm, patientBundles, valueSetMap, 'testLib');
   const patientIDs = ['123', '456'];
 
   const returnedPatient1 = executionResults.patientResults[patientIDs[0]].Patient._json;
@@ -81,7 +93,7 @@ test('Should only load elm JSON with the specified identifier', () => {
   };
 
   // Run the execution utility with testLib elm as well as the secondary Elm
-  const executionResults = execute([elm, secondElm], patientBundle, valueSetMap, 'testLib');
+  const executionResults = execute([elm[0], secondElm], firstPatientBundle, valueSetMap, 'testLib');
 
   const patientID = '123';
 
@@ -92,15 +104,9 @@ test('Should only load elm JSON with the specified identifier', () => {
 
 test('Should default to loading elm with the mCODE identifier', () => {
   // Pulling elm with the mCODE identifier along with its valueSetMap
-  const valueSets = loadJSONFromDirectory(path.resolve(__dirname, '../../valuesets'));
-  const mcodeVSMap = mapValueSets(valueSets);
-  const mcodeElm = loadJSONFromDirectory(path.resolve(__dirname, '../../output-elm'));
 
   // Running the execution utility without a libraryID argument
-  const executionResults = execute(mcodeElm, patientBundle, mcodeVSMap);
-
-  const patientID = '123';
-
-  // Exectuion utility should run with an assumed mCODE libraryID
-  expect(executionResults.localIdPatientResultsMap[patientID]).toHaveProperty('mCODE');
+  expect(() => execute(elm, firstPatientBundle, valueSetMap)).toThrow(
+    Error('Cannot find ELM library with library id mCODE'),
+  );
 });

--- a/testing-harness/test/execution.test.js
+++ b/testing-harness/test/execution.test.js
@@ -1,14 +1,7 @@
 const dotenv = require('dotenv');
 const path = require('path');
 const { execute } = require('../execution');
-const { mapValueSets } = require('../valueSetMapper');
-const {
-  loadJSONFixture,
-  loadJSONFromDirectory,
-  defaultLoadElm,
-  defaultLoadPatients,
-  defaultLoadValuesets,
-} = require('../fixtureLoader');
+const { defaultLoadElm, defaultLoadPatients } = require('../fixtureLoader');
 
 // Initialize the env variables
 dotenv.config({ path: path.resolve(process.cwd(), '.env.test') });
@@ -72,7 +65,6 @@ test('Should properly load patient resource from bundle', () => {
 });
 
 test('Should properly load multiple patient resources from array', () => {
-  const patientBundles = loadJSONFromDirectory(path.resolve(__dirname, './fixtures/patients'));
   const executionResults = execute(elm, patientBundles, valueSetMap, 'testLib');
   const patientIDs = ['123', '456'];
 


### PR DESCRIPTION
Updates the pathing infrastructure of our testing-harness and of the mcode-cql tests to consume all typical paths from .ENV variables. 

Changes of note: 
- Reintroduced dedicated functions for default loaders of the ELM, Valuesets, and Patient fixtures. I still expose the manual fixture loading functions – `loadJSONFromDirectory` and `loadJSONFixture` – but hopefully these dedicated functions help improve usability for our average-case CQL testing. 
- `testing-harness/scripts/buildElm.js` no longer consumes arguments for custom paths; instead, it consumes an optional argument for a custom `.env` file. This allows us to pass a `.env.test` file when we want to translate CQL defined in the testing-harness. This file will become its own `.env` file once the mcode-cql and testing-harness repos are split.
- README updates regarding language pointing users to particular folders
- In our testing-harness tests, we define a test that ensures the `execute` function defines a default libraryId of `mCODE`. Our old approach to this was very round-about, loading the mCODE cql and ensuring that we could parse mCODE off of fixtures. My proposed changes introduce an errorThrow in the event that we cannot find a library of the appropriate id on the provided ELM; this allows us to test this behavior more directly. 